### PR TITLE
aad-login{,.js}: replace parameters by environment variables

### DIFF
--- a/aad-login
+++ b/aad-login
@@ -9,5 +9,6 @@
 #   auth sufficient pam_exec.so expose_authtok /usr/local/bin/aad-login
 
 read password
-node /opt/aad-login/aad-login.js $PAM_USER $password
+export password PAM_USER
+node /opt/aad-login/aad-login.js
 exit $?

--- a/aad-login.js
+++ b/aad-login.js
@@ -14,8 +14,8 @@ if (!directory || !clientid) {
   process.exit(1);
 }
 
-var username = process.argv[2];
-var password = process.argv[3];
+var username = process.env.PAM_USER;
+var password = process.env.password;
 
 if (username && password) {
   request = {


### PR DESCRIPTION
This increases security by not leaking the credentials through the
running process list.

This change is inspired by Jodie Cunningham's[1] pull request[2]
upstream.

[1] https://github.com/jodiecunningham
[2] https://github.com/bureado/aad-login/pull/3